### PR TITLE
Fix large transferred bytes

### DIFF
--- a/agents/windows/plugins/veeam_o365_status.ps1
+++ b/agents/windows/plugins/veeam_o365_status.ps1
@@ -43,7 +43,7 @@ foreach ($o365Job in $o365Jobs)
             $processed = $o365JobLastSession.Statistics.ProcessedObjects -as [int]
 
             if ($o365JobLastSession.Statistics.TransferredData -match '\d+(\.\d+)? [A-Z]B') {
-                $transferred = $(Invoke-Expression -Command ($o365JobLastSession.Statistics.TransferredData -replace ' ')) -as [int]
+                $transferred = $(Invoke-Expression -Command ($o365JobLastSession.Statistics.TransferredData -replace ' ')) -as [long]
             }
 
         } else {

--- a/agents/windows/plugins/veeam_o365_status.ps1
+++ b/agents/windows/plugins/veeam_o365_status.ps1
@@ -42,6 +42,7 @@ foreach ($o365Job in $o365Jobs)
 
             $processed = $o365JobLastSession.Statistics.ProcessedObjects -as [int]
 
+            $transferred = 0
             if ($o365JobLastSession.Statistics.TransferredData -match '\d+(\.\d+)? [A-Z]B') {
                 $transferred = $(Invoke-Expression -Command ($o365JobLastSession.Statistics.TransferredData -replace ' ')) -as [long]
             }


### PR DESCRIPTION
Cast as int will limit transferred bytes to 2GB, sizes above 2GB result in empty transferred.
Fixes #8 