### PR TITLE
fix condition for always ok (False, not None)

### DIFF
--- a/agent_based/veeam_o365licenses.py
+++ b/agent_based/veeam_o365licenses.py
@@ -58,7 +58,7 @@ def check_veeam_o365licenses(item, params, section):
     license_total = int(license_total)
 
     match params.get('licenses', None):
-        case ('always_ok', None):
+        case ('always_ok', False):
             levels = ('no_levels', None)
         case ('absolute', {'warn': warn, 'crit': crit}):
             levels = ('fixed', (license_total - warn, license_total - crit))


### PR DESCRIPTION
When choosing "always ok" in the 2.3 ruleset, the value ist set to ('always_ok', False), not ('always_ok', None), therefore the setting was ignored before this fix